### PR TITLE
Disable running of examples that panic (require gl context).

### DIFF
--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -14,7 +14,7 @@ pub struct VBO(pub GLuint);
 /// Generates vertex array objects
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let mut vao = rgl::VAO(0);
 /// rgl::gen_vertex_arrays(1, &mut vao);
 /// ```
@@ -31,7 +31,7 @@ pub fn gen_vertex_arrays(count: GLsizei, arrays: *mut VAO) {
 /// No need to create the VAO seperatly!
 /// 
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let mut vao = rgl::gen_vertex_array();
 /// ```
 pub fn gen_vertex_array() -> VAO {
@@ -43,7 +43,7 @@ pub fn gen_vertex_array() -> VAO {
 /// Generates some buffer objects
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let mut vbo = rgl::VBO(0);
 /// rgl::gen_buffers(1, &mut vbo);
 /// ```
@@ -59,7 +59,7 @@ pub fn gen_buffers(count: GLsizei, buffers: *mut VBO) {
 /// No need to create the VBO seperatly!
 /// 
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let mut vbo = rgl::gen_buffer();
 /// ```
 pub fn gen_buffer() -> VBO {
@@ -71,7 +71,7 @@ pub fn gen_buffer() -> VBO {
 /// Bind a vertex array object
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let mut vao = rgl::VAO(0);
 /// rgl::gen_vertex_arrays(1, &mut vao);
 /// rgl::bind_vertex_array(vao);
@@ -87,7 +87,7 @@ pub fn bind_vertex_array(array: VAO) {
 /// Bind a vertex buffer
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let vbo = rgl::gen_buffer();
 /// rgl::bind_buffer(rgl::Target::ArrayBuffer, vbo);
 /// ```
@@ -102,7 +102,7 @@ pub fn bind_buffer(target: enums::Target, buffer: VBO) {
 /// Enable a generic vertex attribute array
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// rgl::enable_vertex_attrib_array(0);
 /// ```
 ///
@@ -116,7 +116,7 @@ pub fn enable_vertex_attrib_array(index: GLuint) {
 /// Define an array of generic vertex attribute data
 ///
 /// # Examles
-/// ```
+/// ```rust,no_run
 /// rgl::vertex_attrib_pointer(0, 2, rgl::Type::Float, false, 0);
 /// ```
 ///
@@ -144,7 +144,7 @@ pub fn vertex_attrib_pointer(
 /// Creates and initalizes a buffer object data store
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// extern crate gl;
 /// 
 /// use rgl;

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -8,7 +8,7 @@ use super::enums;
 /// Specify clear values for the color buffers
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// rgl::clear_color(0.5, 0.5, 0.2, 1.0);
 /// ```
 ///
@@ -30,7 +30,7 @@ pub fn clear(mask: GLClearMask) {
 /// Render primitives from array data
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let vbo = rgl::gen_buffer();
 /// //...
 /// rgl::bind_buffer(rgl::Target::ArrayBuffer, vbo);
@@ -47,7 +47,7 @@ pub fn draw_arrays(primitive: enums::Primitive, first: GLint, count: GLsizei) {
 /// Render primitives from array data
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let vao = rgl::gen_vertex_array();
 /// //...
 /// rgl::bind_vertex_array(vao);
@@ -65,7 +65,7 @@ pub fn draw_elements(primitive: enums::Primitive, count: GLsizei, type_: enums::
 /// Draw multiple instances of a set of elements
 ///
 /// # Examples
-/// ```
+/// ```rust,no_run
 /// let vao = rgl::gen_vertex_array();
 /// rgl::bind_vertex_array(vao);
 /// rgl::draw_elements_instanced(rgl::Primitive::Triangles, 36, rgl::Type::UInt, 8);


### PR DESCRIPTION
This should fix the Travis CI failures. It will still ensure that the doc examples compile when `cargo test --all` is run.